### PR TITLE
helm: add node selector config

### DIFF
--- a/docs/missing-container-metrics/Chart.yaml
+++ b/docs/missing-container-metrics/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/docs/missing-container-metrics/templates/daemon-set.yaml
+++ b/docs/missing-container-metrics/templates/daemon-set.yaml
@@ -34,6 +34,8 @@ spec:
         hostPath:
           path: /run/containerd/containerd.sock
       {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/docs/missing-container-metrics/values.yaml
+++ b/docs/missing-container-metrics/values.yaml
@@ -44,3 +44,7 @@ resources: {}
 
 useDocker: false
 useContainerd: true
+
+nodeSelector: {}
+  # Specify on which nodes this should run. E.g.
+  # company.com/nodegroup: "prometheus"


### PR DESCRIPTION
So people can limit on which nodes a certain configuration runs. This is especially helpful when doing Kubernetes updates where nodes configuration need changes.

PW: @parhax 